### PR TITLE
Fix a crash when saving empty nested arrays and objects

### DIFF
--- a/spec/fixtures/factories.js
+++ b/spec/fixtures/factories.js
@@ -1,9 +1,15 @@
 const mongoose = require('mongoose')
 
+const NestedObject = new mongoose.Schema({
+  someProperty: Number,
+})
+
 const SubType = new mongoose.Schema({
   name: String,
   surname: String,
   age: Number,
+  nestedArray: [NestedObject],
+  nestedObject: NestedObject,
 })
 
 global.User = mongoose.model('User', new mongoose.Schema({

--- a/spec/index.js
+++ b/spec/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable func-names */
 process.env.NODE_ENV = 'test'
 process.env.TEST_MONGO_URL = process.env.TEST_MONGO_URL || 'mongodb://localhost/admin-bro-mongoose'
 

--- a/spec/property.spec.js
+++ b/spec/property.spec.js
@@ -68,13 +68,13 @@ describe('Property', function () {
     it('returns an array of all subproperties when nested schema is given', function () {
       const property = new Property(User.schema.paths.parent)
       const subProperties = property.subProperties()
-      expect(subProperties).to.have.lengthOf(4)
+      expect(subProperties).to.have.lengthOf(6)
     })
 
     it('returns an array of all subproperties when array of nested schema is given', function () {
       const property = new Property(User.schema.paths.family)
       const subProperties = property.subProperties()
-      expect(subProperties).to.have.lengthOf(4)
+      expect(subProperties).to.have.lengthOf(6)
     })
   })
 })

--- a/spec/resource.spec.js
+++ b/spec/resource.spec.js
@@ -212,7 +212,32 @@ describe('Resource', function () {
   describe('#create', function () {
     context('correct record', function () {
       beforeEach(async function () {
-        this.params = { email: 'john@doe.com', passwordHash: 'somesecretpasswordhash' }
+        this.params = {
+          email: 'john@doe.com',
+          passwordHash: 'somesecretpasswordhash',
+          'genre.type': 'some type',
+          'genre.enum': 'male',
+          'arrayed.0': 'first',
+          'arrayed.1': 'second',
+          'parent.name': 'name',
+          'parent.surname': 'surname',
+          'parent.age': 12,
+          'parent.nestedArray.0.someProperty': 12,
+          'parent.nestedArray.1.someProperty': 12,
+          'parent.nestedObject.someProperty': 12,
+          'family.0.name': 'some string',
+          'family.0.surname': 'some string',
+          'family.0.age': 13,
+          'family.0.nestedArray.0.someProperty': 12,
+          'family.0.nestedArray.1.someProperty': 12,
+          'family.0.nestedObject.someProperty': 12,
+          'family.1.name': 'some string',
+          'family.1.surname': 'some string',
+          'family.1.age': 14,
+          'family.1.nestedArray.0.someProperty': 12,
+          'family.1.nestedArray.1.someProperty': 12,
+          'family.1.nestedObject.someProperty': 12,
+        }
         this.resource = new Resource(User)
         this.record = await this.resource.create(this.params)
       })
@@ -246,9 +271,7 @@ describe('Resource', function () {
         this.params = {
           email: 'a@a.pl',
           passwordHash: 'asdasdasd',
-          parent: {
-            age: 'not a number',
-          },
+          'parent.age': 'not a number',
         }
         this.resource = new Resource(User)
       })
@@ -256,6 +279,7 @@ describe('Resource', function () {
       it('throws validation error', async function () {
         try {
           await this.resource.create(this.params)
+          expect(true).to.equal(false)
         } catch (error) {
           expect(error).to.be.an.instanceOf(ValidationError)
           expect(error.propertyErrors['parent.age'].type).to.equal('Number')
@@ -266,7 +290,7 @@ describe('Resource', function () {
 
     context('id field passed as an empty string', function () {
       beforeEach(async function () {
-        this.params = { content: '', createdBy: '' }
+        this.params = { content: 'some content', createdBy: '' }
         this.resource = new Resource(Article)
       })
 
@@ -294,6 +318,29 @@ describe('Resource', function () {
       it('creates new resource', async function () {
         const res = await this.resource.create(this.params)
         expect(res.createdBy.toString()).to.equal(this.userRecords[0]._id.toString())
+      })
+    })
+
+    context('record with nested array', function () {
+      beforeEach(async function () {
+        this.params = {
+          email: 'john@doe.com',
+          passwordHash: 'somesecretpasswordhash',
+          'parent.name': 'name',
+          'parent.nestedArray': '',
+          'parent.nestedObject': '',
+          'family.0.name': 'some string',
+          'family.0.nestedArray.0': '',
+          'family.1': '',
+        }
+      })
+
+      it('creates new object', async function () {
+        this.resource = new Resource(User)
+        const countBefore = await this.resource.count()
+        this.record = await this.resource.create(this.params)
+        const countAfter = await this.resource.count()
+        expect(countAfter - countBefore).to.equal(1)
       })
     })
   })

--- a/src/resource.js
+++ b/src/resource.js
@@ -264,7 +264,7 @@ class Resource extends BaseResource {
           parasedParams[fullPath] = []
         } else if (schema && schema.paths) { // we only want arrays of objects (with sub-paths)
           const subProperties = Object.values(schema.paths)
-          // eslint-disable-next-line no-plusplus
+          // eslint-disable-next-line no-plusplus, no-constant-condition
           for (let i = 0; true; i++) { // loop over every item
             const newPrefix = `${fullPath}.${i}`
             if (parasedParams[newPrefix] === '') {
@@ -283,8 +283,12 @@ class Resource extends BaseResource {
 
       // this handles all properties of an object
       if (instance === 'Embedded') {
-        const subProperties = Object.values(schema.paths)
-        subProperties.forEach(handleProperty(fullPath))
+        if (parasedParams[fullPath] === '') {
+          parasedParams[fullPath] = {}
+        } else {
+          const subProperties = Object.values(schema.paths)
+          subProperties.forEach(handleProperty(fullPath))
+        }
       }
     }
 

--- a/src/resource.js
+++ b/src/resource.js
@@ -238,19 +238,57 @@ class Resource extends BaseResource {
    */
   parseParams(params) {
     const parasedParams = { ...params }
-    this.properties().forEach((property) => {
-      const value = parasedParams[property.name()]
-      if (property.mongoosePath.instance === 'ObjectID') {
+
+    // this function handles ObjectIDs and Arrays recursively
+    const handleProperty = (prefix = '') => (property) => {
+      const {
+        path,
+        schema,
+        instance,
+      } = property
+      // mongoose doesn't supply us with the same path as we're using in our data
+      // so we need to improvise
+      const fullPath = [prefix, path].filter(Boolean).join('.')
+      const value = parasedParams[fullPath]
+
+      // this handles missing ObjectIDs
+      if (instance === 'ObjectID') {
         if (value === '') {
-          parasedParams[property.name()] = null
+          parasedParams[fullPath] = null
         }
       }
-      if (property.mongoosePath.instance === 'Array') {
+
+      // this handles empty Arrays or recurses into all properties of a filled Array
+      if (instance === 'Array') {
         if (value === '') {
-          parasedParams[property.name()] = []
+          parasedParams[fullPath] = []
+        } else if (schema && schema.paths) { // we only want arrays of objects (with sub-paths)
+          const subProperties = Object.values(schema.paths)
+          // eslint-disable-next-line no-plusplus
+          for (let i = 0; true; i++) { // loop over every item
+            const newPrefix = `${fullPath}.${i}`
+            if (parasedParams[newPrefix] === '') {
+              // this means we have an empty object here
+              parasedParams[newPrefix] = {}
+            } else if (!Object.keys(parasedParams).some(key => key.startsWith(newPrefix))) {
+              // we're past the last index of this array
+              break
+            } else {
+              // recurse into the object
+              subProperties.forEach(handleProperty(newPrefix))
+            }
+          }
         }
       }
-    })
+
+      // this handles all properties of an object
+      if (instance === 'Embedded') {
+        const subProperties = Object.values(schema.paths)
+        subProperties.forEach(handleProperty(fullPath))
+      }
+    }
+
+    this.properties().forEach(({ mongoosePath }) => handleProperty()(mongoosePath))
 
     return parasedParams
   }


### PR DESCRIPTION
Currently AdminBro sends an empty string in place of an empty array from the frontend. Mongoose integration replaces that string with an empty array only for the top level. So if you send an array of objects and one of those objects is an empty array (represented by the frontend as empty string), your request will fail. The same happens if you send an empty object in your array - it's also represented by an empty string, which triggers an error.

This PR fixes that issue by recursively handling arrays and objects. It introduces some complicated code, so I added a lot of comments explaining what's going on. If you find anything that is not understandable let me know so I can improve those comments.