### PR TITLE
Fix error thrown when handling nested schema error

### DIFF
--- a/spec/utils/create-cast-error.spec.js
+++ b/spec/utils/create-cast-error.spec.js
@@ -5,30 +5,22 @@ const createCastError = require('../../src/utils/create-cast-error')
 
 describe('createCastError', function () {
   context('throwin cast error on update after one key has error', function () {
-    const errorKey = 'parent.age' // because "castError" has been taken for this particular key
-
     beforeEach(function () {
-      this.error = createCastError(castError, {
-        otherKeyWithTheSameErrorValue: castError.value,
-        [errorKey]: castError.value,
-        otherKey: 'othervalue',
-      })
+      this.error = createCastError(castError)
     })
 
     it('has error for nested "parent.age" (errorKey) field', function () {
-      expect(this.error.propertyErrors[errorKey].type).to.equal('Number')
+      expect(this.error.propertyErrors.age.type).to.equal('Number')
     })
   })
 
   context('throwing cast error on update when one array field has error', function () {
     beforeEach(function () {
-      this.error = createCastError(castArrayError, {
-        'authors.1': castArrayError.value,
-      })
+      this.error = createCastError(castArrayError)
     })
 
     it('throws an error for root field', function () {
-      expect(this.error.propertyErrors['authors.1'].type).to.equal('ObjectId')
+      expect(this.error.propertyErrors.authors.type).to.equal('ObjectId')
     })
   })
 })

--- a/src/resource.js
+++ b/src/resource.js
@@ -176,7 +176,7 @@ class Resource extends BaseResource {
       // that is why we have to have a different way of handling them - check out tests to see
       // example error
       if (error.name === MONGOOSE_CAST_ERROR) {
-        throw createCastError(error, parsedParams)
+        throw createCastError(error)
       }
       throw error
     }

--- a/src/utils/create-cast-error.js
+++ b/src/utils/create-cast-error.js
@@ -1,16 +1,12 @@
 const { ValidationError } = require('admin-bro')
 
-const createCastError = (originalError, params) => {
+const createCastError = (originalError) => {
   // cas error has only the nested path. So when an actual path is 'parents.age'
   // originalError will have just a 'age'. That is why we are finding first param
   // with the same value as the error has and path ending the same like path in
   // originalError or ending with path with array notation: "${path}.0"
-  const pathRegex = new RegExp(`${originalError.path}(\\.\\d+)?$`)
-  const errorParam = Object.entries(params).find(([key, value]) => (
-    value === originalError.value && key.match(pathRegex)
-  ))
   const errors = {
-    [errorParam[0]]: {
+    [originalError.path]: {
       message: originalError.message,
       type: originalError.kind || originalError.name,
     },


### PR DESCRIPTION
I removed the code that tries to find a property that caused an error because it did not work for all cases and it caused an error to be thrown and not caught, breaking the request.

Now in case of errors in nested properties the error will simply be attached to the top level property, i.e. the whole array instead of a specific field.