### PR TITLE
Fix validation error handling

### DIFF
--- a/src/utils/create-cast-error.js
+++ b/src/utils/create-cast-error.js
@@ -11,6 +11,6 @@ const createCastError = (originalError) => {
       type: originalError.kind || originalError.name,
     },
   }
-  return new ValidationError(errors)
+  return new ValidationError(undefined, errors)
 }
 module.exports = createCastError

--- a/src/utils/create-validation-error.js
+++ b/src/utils/create-validation-error.js
@@ -11,7 +11,7 @@ const createValidationError = (originalError) => {
       },
     }
   }, {})
-  return new ValidationError(errors)
+  return new ValidationError(undefined, errors)
 }
 
 module.exports = createValidationError


### PR DESCRIPTION
`ValidationError` takes an optional string as the first argument, it was removed so I added it back. There's a default value for it, so I simply passed `undefined` to use that default value.