### PR TITLE
allow hooks to be triggered after a DELETE

### DIFF
--- a/src/resource.js
+++ b/src/resource.js
@@ -189,7 +189,7 @@ class Resource extends BaseResource {
   }
 
   async delete(id) {
-    return this.MongooseModel.deleteOne({ _id: id })
+    return this.MongooseModel.findOneAndRemove({ _id: id })
   }
 
   static stringifyId(mongooseObj) {


### PR DESCRIPTION
Mongoose does not support `Model.deleteOne()` to trigger hooks. It does work when calling `findOneAndRemove`, though.

Here's the hooks I'm using after this change:

```
MySchema.post('findOneAndUpdate', async (doc, next) => {/* ... */});
MySchema.post('findOneAndRemove', async (doc, next) => {/* ... */});
```