### PR TITLE
Fix utils create validation error. Parse "ValidationError"

### DIFF
--- a/src/utils/create-validation-error.ts
+++ b/src/utils/create-validation-error.ts
@@ -1,15 +1,29 @@
 import { ValidationError } from 'admin-bro'
 
 export const createValidationError = (originalError): ValidationError => {
-  const errors = Object.keys(originalError.errors).reduce((memo, key) => {
-    const { message, kind, name } = originalError.errors[key]
-    return {
+  let errors
+  if (originalError.errors) {
+    errors = Object.keys(originalError.errors).reduce((memo, key) => {
+      const { message, kind, name } = originalError.errors[key]
+      return {
+        ...memo,
+        [key]: {
+          message,
+          type: kind || name,
+        },
+      }
+    }, {})
+  }
+
+  if (originalError.name && originalError.name === 'ValidationError') {
+    errors = Object.keys(originalError.data).reduce((memo, key) => ({
       ...memo,
       [key]: {
-        message,
-        type: kind || name,
+        message: originalError.data[key],
+        type: originalError.name,
       },
-    }
-  }, {})
+    }), {})
+  }
+
   return new ValidationError(errors)
 }


### PR DESCRIPTION
The utils `create-validation-error.ts` not parse the error: 
```
{
  name: 'ValidationError',
  data: { email: 'Invalid email address' }
}
```

In the future, I think there will still be errors that he will fail to parse. 