### PR TITLE
Add select fields, add toObject

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -71,7 +71,7 @@ class Resource extends BaseResource {
     }
 
     async count(filters = null) {
-      return this.MongooseModel.count(convertFilter(filters))
+      return this.MongooseModel.countDocuments(convertFilter(filters))
     }
 
     async find(filters = {}, { limit = 20, offset = 0, sort = {} }: FindOptions) {
@@ -164,7 +164,7 @@ class Resource extends BaseResource {
       // raw object it changes _id field not to a string but to an object.
       // stringify/parse is a path found here: https://github.com/Automattic/mongoose/issues/2790
       // @todo We can somehow speed this up
-      const strinigified = JSON.stringify(mongooseObj)
+      const strinigified = JSON.stringify('toObject' in mongooseObj ? mongooseObj.toObject({getters: true, virtuals: true}): mongooseObj)
       return JSON.parse(strinigified)
     }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -55,6 +55,10 @@ class Resource extends BaseResource {
     id() {
       return this.MongooseModel.modelName
     }
+    
+    get selectFields(){
+      return Object.keys(this.MongooseModel.schema.paths).join(' ');
+    }
 
     properties() {
       return Object.entries(this.MongooseModel.schema.paths).map(([, path], position) => (
@@ -77,7 +81,7 @@ class Resource extends BaseResource {
       }
       const mongooseObjects = await this.MongooseModel
         .find(convertFilter(filters), {}, {
-          skip: offset, limit, sort: sortingParam,
+          skip: offset, limit, sort: sortingParam, select: this.selectFields
         })
       return mongooseObjects.map(mongooseObject => new BaseRecord(
         Resource.stringifyId(mongooseObject), this,
@@ -85,7 +89,7 @@ class Resource extends BaseResource {
     }
 
     async findOne(id:string) {
-      const mongooseObject = await this.MongooseModel.findById(id)
+      const mongooseObject = await this.MongooseModel.findById(id).select(this.selectFields)
       return new BaseRecord(Resource.stringifyId(mongooseObject), this)
     }
 
@@ -93,6 +97,7 @@ class Resource extends BaseResource {
       const mongooseObjects = await this.MongooseModel.find(
         { _id: ids },
         {},
+        {select: this.selectFields}
       )
       return mongooseObjects.map(mongooseObject => (
         new BaseRecord(Resource.stringifyId(mongooseObject), this)


### PR DESCRIPTION
Add select fields to each find query, this will be usefull if you set {select: false} in mongoose schema.
Add mongooseObj.toObject method call in stringifyId function for right Decimal128 displaing in admin-bro frontend.